### PR TITLE
Fix mislabeled token for IW5 (_fire_noplayer -> handleDamage)

### DIFF
--- a/src/iw5/xsk/resolver.cpp
+++ b/src/iw5/xsk/resolver.cpp
@@ -6619,7 +6619,7 @@ const std::array<std::pair<std::uint16_t, const char*>, 5534> token_list
     { 13637, "getBestSpawnPoint" },
     { 13638, "spawnScore" },
     { 13639, "_fire" },
-    { 13640, "_fire_noplayer" },
+    { 13640, "handleDamage" },
     { 13641, "MissileEyes" },
     { 13642, "delayedFOFOverlay" },
     { 13643, "staticEffect" },


### PR DESCRIPTION
https://github.com/chxseh/MW3-GSC-Dump/blob/main/_wii-gsc-dump/maps/mp/killstreaks/_remotemissile.gsc#L198

Currently breaks compiling Bot Warfare, this fixes it.