### PR TITLE
feat(arc): add optional arg for filename in gscobj header

### DIFF
--- a/include/xsk/arc/assembler.hpp
+++ b/include/xsk/arc/assembler.hpp
@@ -25,7 +25,7 @@ class assembler
 
 public:
     assembler(context const* ctx);
-    auto assemble(assembly const& data, std::string const& string = {}) -> buffer;
+    auto assemble(assembly const& data, std::string const& name = {}) -> buffer;
 
 private:
     auto assemble_function(function& func) -> void;

--- a/include/xsk/arc/assembler.hpp
+++ b/include/xsk/arc/assembler.hpp
@@ -25,7 +25,7 @@ class assembler
 
 public:
     assembler(context const* ctx);
-    auto assemble(assembly const& data) -> buffer;
+    auto assemble(assembly const& data, std::string const& string = "") -> buffer;
 
 private:
     auto assemble_function(function& func) -> void;

--- a/include/xsk/arc/assembler.hpp
+++ b/include/xsk/arc/assembler.hpp
@@ -25,7 +25,7 @@ class assembler
 
 public:
     assembler(context const* ctx);
-    auto assemble(assembly const& data, std::string const& string = "") -> buffer;
+    auto assemble(assembly const& data, std::string const& string = {}) -> buffer;
 
 private:
     auto assemble_function(function& func) -> void;

--- a/src/arc/assembler.cpp
+++ b/src/arc/assembler.cpp
@@ -14,7 +14,7 @@ assembler::assembler(context const* ctx) : ctx_{ ctx }, script_{ ctx->endian() =
 {
 }
 
-auto assembler::assemble(assembly const& data, std::string const& filename) -> buffer
+auto assembler::assemble(assembly const& data, std::string const& name) -> buffer
 {
     assembly_ = &data;
     script_.clear();
@@ -26,7 +26,7 @@ auto assembler::assemble(assembly const& data, std::string const& filename) -> b
     auto head = header{};
 
     script_.pos((ctx_->props() & props::headerxx) ? 0 : (ctx_->props() & props::header72) ? 72 : 64);
-    process_string(filename);
+    process_string(name);
 
     for (auto const& func : assembly_->functions)
     {
@@ -183,7 +183,7 @@ auto assembler::assemble(assembly const& data, std::string const& filename) -> b
     head.profile_count = 0;
 
     head.flags = 0;
-    head.name = resolve_string(filename);
+    head.name = resolve_string(name);
 
     auto endpos = script_.pos();
 

--- a/src/arc/assembler.cpp
+++ b/src/arc/assembler.cpp
@@ -14,7 +14,7 @@ assembler::assembler(context const* ctx) : ctx_{ ctx }, script_{ ctx->endian() =
 {
 }
 
-auto assembler::assemble(assembly const& data) -> buffer
+auto assembler::assemble(assembly const& data, std::string const& filename) -> buffer
 {
     assembly_ = &data;
     script_.clear();
@@ -26,7 +26,7 @@ auto assembler::assemble(assembly const& data) -> buffer
     auto head = header{};
 
     script_.pos((ctx_->props() & props::headerxx) ? 0 : (ctx_->props() & props::header72) ? 72 : 64);
-    process_string("");
+    process_string(filename);
 
     for (auto const& func : assembly_->functions)
     {
@@ -183,7 +183,7 @@ auto assembler::assemble(assembly const& data) -> buffer
     head.profile_count = 0;
 
     head.flags = 0;
-    head.name = resolve_string("");
+    head.name = resolve_string(filename);
 
     auto endpos = script_.pos();
 


### PR DESCRIPTION
Allows integrations of gsc-tool to pass the filename to the assembler.