### PR TITLE
fix(arc): typo that generates invalid syntax

### DIFF
--- a/src/arc/source.cpp
+++ b/src/arc/source.cpp
@@ -1410,7 +1410,7 @@ auto source::dump_expr_getdvarint(expr_getdvarint const& exp) -> void
 
 auto source::dump_expr_getdvarfloat(expr_getdvarfloat const& exp) -> void
 {
-    fmt::format_to(std::back_inserter(buf_), "getdvarflaot( ");
+    fmt::format_to(std::back_inserter(buf_), "getdvarfloat( ");
     dump_expr(*exp.arg);
     fmt::format_to(std::back_inserter(buf_), " )");
 }


### PR DESCRIPTION
Changes `getdvarflaot` to `getdvarfloat`.