### PR TITLE
fix(gsc): fs_read checks multiple files for includes

### DIFF
--- a/include/xsk/gsc/context.hpp
+++ b/include/xsk/gsc/context.hpp
@@ -18,7 +18,7 @@ namespace xsk::gsc
 class context
 {
 public:
-    using fs_callback = std::function<std::pair<buffer, std::vector<u8>>(std::string const&)>;
+    using fs_callback = std::function<std::pair<buffer, std::vector<u8>>(std::string const&, context&)>;
 
     context(props props, engine engine, endian endian, system system, u32 str_count);
 

--- a/include/xsk/gsc/context.hpp
+++ b/include/xsk/gsc/context.hpp
@@ -18,7 +18,7 @@ namespace xsk::gsc
 class context
 {
 public:
-    using fs_callback = std::function<std::pair<buffer, std::vector<u8>>(std::string const&, context&)>;
+    using fs_callback = std::function<std::pair<buffer, std::vector<u8>>(context const*, std::string const&)>;
 
     context(props props, engine engine, endian endian, system system, u32 str_count);
 

--- a/src/gsc/context.cpp
+++ b/src/gsc/context.cpp
@@ -682,7 +682,7 @@ auto context::load_header(std::string const& name) -> std::tuple<std::string con
         return { &itr->first, reinterpret_cast<char const*>(itr->second.data()), itr->second.size() };
     }
 
-    auto data = fs_callback_(name);
+    auto data = fs_callback_(name, *this);
 
     if (data.first.data == nullptr && data.first.size == 0 && !data.second.empty())
     {
@@ -711,7 +711,7 @@ auto context::load_include(std::string const& name) -> bool
         if (include_cache_.contains(name))
             return true;
 
-        auto file = fs_callback_(name);
+        auto file = fs_callback_(name, *this);
 
         if ((file.first.data == nullptr || file.first.size == 0) && file.second.empty())
             throw std::runtime_error("empty file");

--- a/src/gsc/context.cpp
+++ b/src/gsc/context.cpp
@@ -682,7 +682,7 @@ auto context::load_header(std::string const& name) -> std::tuple<std::string con
         return { &itr->first, reinterpret_cast<char const*>(itr->second.data()), itr->second.size() };
     }
 
-    auto data = fs_callback_(name, *this);
+    auto data = fs_callback_(this, name);
 
     if (data.first.data == nullptr && data.first.size == 0 && !data.second.empty())
     {
@@ -700,7 +700,7 @@ auto context::load_header(std::string const& name) -> std::tuple<std::string con
 auto context::load_include(std::string const& name) -> bool
 {
     try
-    { 
+    {
         if (includes_.contains(name))
         {
             return false;
@@ -711,7 +711,10 @@ auto context::load_include(std::string const& name) -> bool
         if (include_cache_.contains(name))
             return true;
 
-        auto file = fs_callback_(name, *this);
+        auto filename = name;
+        filename += (instance_ == gsc::instance::server) ? ".gsc" : ".csc";
+
+        auto file = fs_callback_(this, filename);
 
         if ((file.first.data == nullptr || file.first.size == 0) && file.second.empty())
             throw std::runtime_error("empty file");

--- a/src/tool/main.cpp
+++ b/src/tool/main.cpp
@@ -436,9 +436,11 @@ auto fs_read(context const* ctx, std::string const& name) -> std::pair<buffer, s
 {
     auto path = fs::path{ name };
 
-    if (!utils::file::exists(path) && !path.has_extension())
+    if (!utils::file::exists(path))
     {
-        auto id = ctx.token_id(name);
+        path.replace_extension("");
+
+        auto id = ctx->token_id(path.string());
         if (id > 0)
         {
             path = fs::path{ std::to_string(id) + ".gscbin" };
@@ -446,17 +448,17 @@ auto fs_read(context const* ctx, std::string const& name) -> std::pair<buffer, s
 
         if (!utils::file::exists(path))
         {
-            path = fs::path{ name + ".gscbin" };
+            path = fs::path{ path.string() + ".gscbin" };
         }
 
         if (!utils::file::exists(path))
         {
-            path = fs::path{ name + ".gsh" };
+            path = fs::path{ path.string() + ".gsh" };
         }
 
         if (!utils::file::exists(path))
         {
-            path = fs::path{ name + ".gsc" };
+            path = fs::path{ path.string() + ".gsc" };
         }
     }
 

--- a/src/tool/main.cpp
+++ b/src/tool/main.cpp
@@ -432,16 +432,42 @@ auto rename_file(game game, mach mach, fs::path file, fs::path rel) -> result
 
 std::unordered_map<std::string, std::vector<std::uint8_t>> files;
 
-auto fs_read(std::string const& name) -> std::pair<buffer, std::vector<u8>>
+auto fs_read(std::string const& name, context& ctx) -> std::pair<buffer, std::vector<u8>>
 {
-    auto data = utils::file::read(fs::path{ name });
+    auto path = fs::path{ name };
+
+    if (!utils::file::exists(path) && !path.has_extension())
+    {
+        auto id = ctx.token_id(name);
+        if (id > 0)
+        {
+            path = fs::path{ std::to_string(id) + ".gscbin" };
+        }
+
+        if (!utils::file::exists(path))
+        {
+            path = fs::path{ name + ".gscbin" };
+        }
+
+        if (!utils::file::exists(path))
+        {
+            path = fs::path{ name + ".gsh" };
+        }
+
+        if (!utils::file::exists(path))
+        {
+            path = fs::path{ name + ".gsc" };
+        }
+    }
+
+    auto data = utils::file::read(path);
     
-    if(name.ends_with(".gscbin") || (!name.ends_with(".gsh") && !name.ends_with(".gsc")))
+    if (path.extension().string() == ".gscbin" || (path.extension().string() != ".gsh" && path.extension().string() != ".gsc"))
     {
         asset s;
         s.deserialize(data);
         auto stk = utils::zlib::decompress(s.buffer, s.len);
-        auto res = files.insert({ name, std::move(s.bytecode) });
+        auto res = files.insert({ path.filename().string(), std::move(s.bytecode)});
 
         if (res.second)
         {

--- a/src/tool/main.cpp
+++ b/src/tool/main.cpp
@@ -432,7 +432,7 @@ auto rename_file(game game, mach mach, fs::path file, fs::path rel) -> result
 
 std::unordered_map<std::string, std::vector<std::uint8_t>> files;
 
-auto fs_read(std::string const& name, context& ctx) -> std::pair<buffer, std::vector<u8>>
+auto fs_read(context const* ctx, std::string const& name) -> std::pair<buffer, std::vector<u8>>
 {
     auto path = fs::path{ name };
 


### PR DESCRIPTION
Currently, the fs_read isn't that useful, it assumes that the `name` it receives has an extension, which it doesn't, it only receives the literal token after the `#include`, This fixes that; it will also check the token_ids if it exists.