### PR TITLE
feat(build): add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM alpine:3.19
+
+# glibc compatibility
+RUN apk add --no-cache gcompat libstdc++
+
+# copy gsc-tool
+COPY --chmod=755 gsc-tool /usr/local/bin/
+
+ENTRYPOINT ["/usr/local/bin/gsc-tool"]


### PR DESCRIPTION
Alpine-based Docker image for running a precompiled gsc-tool binary (tested with latest linux-x64 artifact).
For ease of use, this image could be automatically built in a workflow (using the linux artifacts) and pushed to GitHub's [container registry](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry).