### PR TITLE
build(actions): add windows arm64

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,6 +30,7 @@ jobs:
         arch:
           - x86
           - x64
+          - arm64
         include:
           - arch: x86
             platform: Win32

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,6 +35,8 @@ jobs:
             platform: Win32
           - arch: x64
             platform: x64
+          - arch: arm64
+            platform: arm64
     steps:
       - name: Check out files
         uses: actions/checkout@v4


### PR DESCRIPTION
This PR adds support for building gsc-tool for the Windows ARM 64 platform