### PR TITLE
feat: add custom hash callback with define to disable compiled ones

### DIFF
--- a/include/xsk/arc/context.hpp
+++ b/include/xsk/arc/context.hpp
@@ -19,6 +19,7 @@ struct context
 {
 public:
     using fs_callback = std::function<std::vector<u8>(std::string const&)>;
+    using hash_callback = std::function<const char* (u32 hash)>;
 
     context(props props, engine engine, endian endian, system system, instance inst, u64 magic);
 
@@ -37,6 +38,9 @@ public:
 
     auto fixup(bool value) -> void { fixup_ = value; }
     auto fixup() const -> bool { return fixup_; }
+
+    auto unhash_func(hash_callback value) -> void { unhash_func_ = value; }
+    auto unhash_func() const -> hash_callback { return unhash_func_; }
 
     auto init(arc::build build, fs_callback callback) -> void;
     auto cleanup() -> void;
@@ -66,13 +70,14 @@ protected:
     arc::compiler compiler_;
     arc::decompiler decompiler_;
     bool fixup_{ false };
+    hash_callback unhash_func_{};
 
     fs_callback fs_callback_;
     std::unordered_map<opcode, std::string_view> opcode_map_;
     std::unordered_map<std::string_view, opcode> opcode_map_rev_;
     std::unordered_map<u16, opcode> code_map_;
     std::unordered_map<opcode, u16> code_map_rev_;
-    std::unordered_map<u32, std::string_view> hash_map_;
+    std::unordered_map<u64, std::string_view> hash_map_;
     std::unordered_map<std::string, std::vector<u8>> header_files_;
 };
 

--- a/include/xsk/arc/engine/t6.hpp
+++ b/include/xsk/arc/engine/t6.hpp
@@ -11,7 +11,12 @@
 namespace xsk::arc::t6
 {
 
-constexpr usize code_count = 125;
-constexpr usize hash_count = 3809;
+	constexpr usize code_count = 125;
+
+#ifdef XSK_NO_COMPILED_HASH
+	constexpr usize hash_count = 0;
+#else // !XSK_NO_COMPILED_HASH
+	constexpr usize hash_count = 3809;
+#endif // XSK_NO_COMPILED_HASH
 
 } // namespace xsk::arc::t6

--- a/include/xsk/arc/engine/t7.hpp
+++ b/include/xsk/arc/engine/t7.hpp
@@ -12,7 +12,13 @@ namespace xsk::arc::t7
 {
 
 constexpr usize code_count = 16384;
+
+#ifdef XSK_NO_COMPILED_HASH
+constexpr usize hash_count = 0;
+#else // !XSK_NO_COMPILED_HASH
 constexpr usize hash_count = 178806;
+#endif // XSK_NO_COMPILED_HASH
+
 constexpr u64 header_magic = 0x1C000A0D43534780;
 
 struct context : public arc::context

--- a/include/xsk/gsc/context.hpp
+++ b/include/xsk/gsc/context.hpp
@@ -19,6 +19,7 @@ struct context
 {
 public:
     using fs_callback = std::function<std::pair<buffer, std::vector<u8>>(context const*, std::string const&)>;
+    using hash_callback = std::function<const char* (u64 hash)>;
 
     context(props props, engine engine, endian endian, system system, instance inst, u32 str_count);
 
@@ -48,6 +49,9 @@ public:
 
     auto func_map() const -> std::unordered_map<std::string_view, u16> const& { return func_map_rev_; }
     auto meth_map() const -> std::unordered_map<std::string_view, u16> const& { return meth_map_rev_; }
+
+    auto unhash_func(hash_callback value) -> void { unhash_func_ = value; }
+    auto unhash_func() const -> hash_callback { return unhash_func_; }
 
     auto init(gsc::build build, fs_callback callback) -> void;
 
@@ -124,6 +128,7 @@ protected:
     gsc::disassembler disassembler_;
     gsc::compiler compiler_;
     gsc::decompiler decompiler_;
+    hash_callback unhash_func_{};
     fs_callback fs_callback_;
     std::unordered_map<opcode, std::string_view> opcode_map_;
     std::unordered_map<std::string_view, opcode> opcode_map_rev_;

--- a/include/xsk/gsc/engine/iw9.hpp
+++ b/include/xsk/gsc/engine/iw9.hpp
@@ -15,7 +15,12 @@ constexpr usize code_count = 167;
 constexpr usize func_count = 905;
 constexpr usize meth_count = 1469;
 constexpr usize path_count = 1467;
+
+#ifdef XSK_NO_COMPILED_HASH
+constexpr usize hash_count = 0;
+#else // !XSK_NO_COMPILED_HASH
 constexpr usize hash_count = 73500;
+#endif // XSK_NO_COMPILED_HASH
 
 struct context : public gsc::context
 {

--- a/premake5.lua
+++ b/premake5.lua
@@ -1,4 +1,13 @@
 -------------------------------------------------
+-- OPTIONS
+-------------------------------------------------
+
+newoption {
+   trigger = "no-compiled-hash",
+   description = "Remove hash compilation from the build."
+}
+
+-------------------------------------------------
 -- DEPENDENCIES
 -------------------------------------------------
 dependencies = { base = path.getrelative(os.getcwd(), path.getabsolute("deps")) }
@@ -147,6 +156,11 @@ workspace "gsc-tool"
     filter { "system:macosx", "platforms:arm64" }
         buildoptions "-arch arm64"
         linkoptions "-arch arm64"
+    filter {}
+
+    -- options
+    filter { "options:no-compiled-hash" }
+        defines { "XSK_NO_COMPILED_HASH" }
     filter {}
 
 project "xsk-tool"

--- a/src/arc/context.cpp
+++ b/src/arc/context.cpp
@@ -296,6 +296,16 @@ auto context::hash_id(std::string const& name) const -> u32
 
 auto context::hash_name(u32 id) const -> std::string
 {
+    if (unhash_func_)
+    {
+        auto extracted = unhash_func_(id);
+
+        if (extracted)
+        {
+            return extracted;
+        }
+    }
+
     auto const itr = hash_map_.find(id);
 
     if (itr != hash_map_.end())

--- a/src/arc/engine/t6_hash.cpp
+++ b/src/arc/engine/t6_hash.cpp
@@ -10,6 +10,8 @@ namespace xsk::arc::t6
 
 extern std::array<std::pair<u32, char const*>, hash_count> const hash_list
 {{
+#ifndef XSK_NO_COMPILED_HASH
+
     { 0x146F2C73, "ClickToContinue" },
     { 0x209FFF3B, "FriendXuidToJoinOnBoot" },
     { 0x586EB87C, "TestIntervalJitter" },
@@ -3819,6 +3821,8 @@ extern std::array<std::pair<u32, char const*>, hash_count> const hash_list
     { 0xD7BCDBE2, "zombies_perk_vulture_points_chance" },
     { 0x47A03A7E, "zombies_perk_vulture_spawn_stink_zombie_cooldown" },
     { 0x4918C38E, "zombies_perk_vulture_stink_chance" },
+
+#endif // !XSK_NO_COMPILED_HASH
 }};
 
 } // namespace xsk::arc::t6

--- a/src/arc/engine/t7_hash.cpp
+++ b/src/arc/engine/t7_hash.cpp
@@ -8,8 +8,11 @@
 namespace xsk::arc::t7
 {
 
+
 extern std::array<std::pair<u32, char const*>, hash_count> const hash_list
 {{
+#ifndef XSK_NO_COMPILED_HASH
+
     { 0x05C00BF0, "_" },
     { 0x5D7A7160, "_0" },
     { 0x6D3AFA7F, "_1h_rappel_start" },
@@ -178816,6 +178819,8 @@ extern std::array<std::pair<u32, char const*>, hash_count> const hash_list
     { 0xD04A6B04, "zurich" },
     { 0x0FEB9892, "zval" },
     { 0xEC2C073C, "zvar" },
+
+#endif // !XSK_NO_COMPILED_HASH
 }};
 
 } // namespace xsk::arc::t7

--- a/src/gsc/context.cpp
+++ b/src/gsc/context.cpp
@@ -645,6 +645,16 @@ auto context::hash_id(std::string const& name) const -> u64
 
 auto context::hash_name(u64 id) const -> std::string
 {
+    if (unhash_func_)
+    {
+        auto extracted = unhash_func_(id);
+
+        if (extracted)
+        {
+            return extracted;
+        }
+    }
+
    auto const itr = hash_map_.find(id);
 
     if (itr != hash_map_.end())

--- a/src/gsc/engine/iw9_hash.cpp
+++ b/src/gsc/engine/iw9_hash.cpp
@@ -10,6 +10,8 @@ namespace xsk::gsc::iw9
 
 extern std::array<std::pair<u64, char const*>, hash_count> const hash_list
 {{
+#ifndef XSK_NO_COMPILED_HASH
+
     { 0xAC0E9D4AC96B3934, "-" },
     { 0xAC0E2F4AC96A474A, "_" },
     { 0x7A01D32B5E35730B, "__ending_origin" },
@@ -73510,6 +73512,8 @@ extern std::array<std::pair<u64, char const*>, hash_count> const hash_list
     { 0xCA5FC0B4F8114CAC, "zpatrolpointscoring" },
     { 0x57970A7665AE52E9, "zuluinit" },
     { 0x4CA8EF8D936C1E3E, "zvelscale" },
+
+#endif // !XSK_NO_COMPILED_HASH
 }};
 
 } // namespace xsk::gsc::iw9


### PR DESCRIPTION
I've added in the arc and gsc context a callback so we can provide custom hashes. To avoid having two systems loading hashes, I've added a define called `XSK_NO_COMPILED_HASH` to disable their compilation