### PR TITLE
fix: add space after while's opening parenthesis in dowhile

### DIFF
--- a/src/arc/source.cpp
+++ b/src/arc/source.cpp
@@ -682,7 +682,7 @@ auto source::dump_stmt_dowhile(stmt_dowhile const& stm) -> void
     }
     else
     {
-        std::format_to(std::back_inserter(buf_), "\n{: >{}}while (", "", indent_);
+        std::format_to(std::back_inserter(buf_), "\n{: >{}}while ( ", "", indent_);
         dump_expr(*stm.test);
         std::format_to(std::back_inserter(buf_), " );");
     }

--- a/src/gsc/source.cpp
+++ b/src/gsc/source.cpp
@@ -730,7 +730,7 @@ auto source::dump_stmt_dowhile(stmt_dowhile const& stm) -> void
     }
     else
     {
-        std::format_to(std::back_inserter(buf_), "\n{: >{}}while (", "", indent_);
+        std::format_to(std::back_inserter(buf_), "\n{: >{}}while ( ", "", indent_);
         dump_expr(*stm.test);
         std::format_to(std::back_inserter(buf_), " );");
     }


### PR DESCRIPTION
Current code results in this:
```gsc
do
{
    // code
}
while (condition );
```
This PR changes it to result in this:
```gsc
do
{
    // code
}
while ( condition );
```