### PR TITLE
Add support for the updated IW5 PC x64 bytecode layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ A utility to compile & decompile IW engine game scripts.
 
     ``--t6fixup`` Decompile t6 files from broken compilers.
 
+    ``--iw5x64`` Use the updated IW5 PC x64 bytecode layout.
+
     ``-h, --help`` Display help.
 
     ``-v, --version`` Display version.

--- a/include/xsk/gsc/common/types.hpp
+++ b/include/xsk/gsc/common/types.hpp
@@ -84,6 +84,7 @@ struct feature
         hash       = 1 << 9,  // iw9 identifiers
         farcall    = 1 << 10, // iw9 new call system
         foreach    = 1 << 11, // iw9 foreach
+        anim4      = 1 << 12, // animation references use 4-byte offsets
     };
 
     feature(const values value) : value_(value) {}

--- a/include/xsk/gsc/engine/iw5_pc.hpp
+++ b/include/xsk/gsc/engine/iw5_pc.hpp
@@ -20,7 +20,7 @@ constexpr u32 max_string_id = 33386;
 struct context : public gsc::context
 {
 public:
-    explicit context(gsc::instance inst);
+    explicit context(gsc::instance inst, bool x64 = false);
 };
 
 } // namespace xsk::gsc::iw5_pc

--- a/src/gsc/assembler.cpp
+++ b/src/gsc/assembler.cpp
@@ -191,7 +191,7 @@ auto assembler::assemble_instruction(instruction const& inst) -> void
             stack_.write_cstr(encrypt_string(inst.data[0]));
             break;
         case opcode::OP_GetAnimation:
-            if (ctx_->features() & feature::str4)
+            if ((ctx_->features() & feature::str4) || (ctx_->features() & feature::anim4))
                 script_.write<u64>(0);
             else
                 script_.write<u32>(0);

--- a/src/gsc/context.cpp
+++ b/src/gsc/context.cpp
@@ -244,7 +244,7 @@ auto context::opcode_size(opcode op) const -> usize
         case opcode::OP_GetIString:
             return (features_ & feature::str4) ? 5 : 3;
         case opcode::OP_GetAnimation:
-            return (features_ & feature::str4) ? 9 : 5;
+            return ((features_ & feature::str4) || (features_ & feature::anim4)) ? 9 : 5;
         case opcode::OP_GetVector:
             return 13;
         case opcode::OP_ClearVariableField:

--- a/src/gsc/disassembler.cpp
+++ b/src/gsc/disassembler.cpp
@@ -184,7 +184,7 @@ auto disassembler::dissasemble_instruction(instruction& inst) -> void
             inst.data.push_back(decrypt_string(stack_.read_cstr()));
             break;
         case opcode::OP_GetAnimation:
-            script_.seek((ctx_->features() & feature::str4) ? 8 : 4);
+            script_.seek(((ctx_->features() & feature::str4) || (ctx_->features() & feature::anim4)) ? 8 : 4);
             inst.data.push_back(decrypt_string(stack_.read_cstr()));
             inst.data.push_back(decrypt_string(stack_.read_cstr()));
             break;

--- a/src/gsc/engine/iw5_pc.cpp
+++ b/src/gsc/engine/iw5_pc.cpp
@@ -13,8 +13,10 @@ extern std::array<std::pair<u16, char const*>, func_count> const func_list;
 extern std::array<std::pair<u16, char const*>, meth_count> const meth_list;
 extern std::array<std::pair<u32, char const*>, token_count> const token_list;
 
-context::context(gsc::instance inst) : gsc::context(feature::none, engine::iw5, endian::little, system::pc, inst, max_string_id)
+context::context(gsc::instance inst, bool x64)
+    : gsc::context(x64 ? feature::anim4 : feature::none, engine::iw5, endian::little, system::pc, inst, max_string_id)
 {
+    // The x64 build widens animation references only; regular IW5 string references remain 16-bit.
     code_map_.reserve(code_list.size());
     code_map_rev_.reserve(code_list.size());
     func_map_.reserve(func_list.size());

--- a/src/tool/main.cpp
+++ b/src/tool/main.cpp
@@ -174,6 +174,7 @@ namespace gsc
 std::map<game, std::map<mach, std::unique_ptr<context>>> contexts;
 std::map<mode, std::function<result(game game, mach mach, fs::path file, fs::path rel)>> funcs;
 bool zonetool = false;
+bool iw5x64 = false;
 
 auto assemble_file(game game, mach mach, const fs::path& file, fs::path rel) -> result
 {
@@ -543,7 +544,7 @@ auto init_iw5(mach mach, inst inst, bool dev) -> void
     {
         case mach::pc:
         {
-            contexts[game::iw5][mach] = std::make_unique<iw5_pc::context>(inst == inst::client ? gsc::instance::client : gsc::instance::server);
+            contexts[game::iw5][mach] = std::make_unique<iw5_pc::context>(inst == inst::client ? gsc::instance::client : gsc::instance::server, iw5x64);
             contexts[game::iw5][mach]->init(dev ? build::dev : build::prod, fs_read);
             break;
         }
@@ -1242,6 +1243,7 @@ auto main(u32 argc, char** argv) -> result
         ("d,dev", "Enable developer mode (dev blocks & generate bytecode map).", cxxopts::value<bool>()->implicit_value("true"))
         ("z,zonetool", "Enable zonetool mode (use .cgsc files).", cxxopts::value<bool>()->implicit_value("true"))
         ("t6fixup", "Decompile t6 files from broken compilers.", cxxopts::value<bool>()->implicit_value("true"))
+        ("iw5x64", "Use the 2026 IW5 PC x64 bytecode layout.", cxxopts::value<bool>()->implicit_value("true"))
         ("h,help", "Display help.")
         ("v,version", "Display version.");
 
@@ -1300,6 +1302,7 @@ auto main(u32 argc, char** argv) -> result
         auto inst = inst::_;
         auto dev = result["dev"].as<bool>();
         gsc::zonetool = result["zonetool"].as<bool>();
+        gsc::iw5x64 = result["iw5x64"].as<bool>();
         arc::t6fixup = result["t6fixup"].as<bool>();
         dry_run = result["dry"].as<bool>();
 

--- a/src/tool/main.cpp
+++ b/src/tool/main.cpp
@@ -174,7 +174,6 @@ namespace gsc
 std::map<game, std::map<mach, std::unique_ptr<context>>> contexts;
 std::map<mode, std::function<result(game game, mach mach, fs::path file, fs::path rel)>> funcs;
 bool zonetool = false;
-bool iw5x64 = false;
 
 auto assemble_file(game game, mach mach, const fs::path& file, fs::path rel) -> result
 {
@@ -536,7 +535,7 @@ auto fs_read(context const* ctx, std::string const& name) -> std::pair<buffer, s
     throw std::runtime_error("file read error");
 }
 
-auto init_iw5(mach mach, inst inst, bool dev) -> void
+auto init_iw5(mach mach, inst inst, bool dev, bool iw5x64) -> void
 {
     if (contexts[game::iw5].contains(mach)) return;
 
@@ -742,7 +741,7 @@ auto init_h2(mach mach, inst inst, bool dev) -> void
     }
 }
 
-auto init(game game, mach mach, inst inst, bool dev) -> void
+auto init(game game, mach mach, inst inst, bool dev, bool iw5x64) -> void
 {
     funcs[mode::assemble] = assemble_file;
     funcs[mode::disassemble] = disassemble_file;
@@ -758,7 +757,7 @@ auto init(game game, mach mach, inst inst, bool dev) -> void
 
     switch (game)
     {
-        case game::iw5: init_iw5(mach, inst, dev); break;
+        case game::iw5: init_iw5(mach, inst, dev, iw5x64); break;
         case game::iw6: init_iw6(mach, inst, dev); break;
         case game::iw7: init_iw7(mach, inst, dev); break;
         case game::iw8: init_iw8(mach, inst, dev); break;
@@ -1112,9 +1111,9 @@ auto extension_match(fs::path const& ext, mode mode, game game) -> bool
     }
 }
 
-auto execute(mode mode, game game, mach mach, inst inst, fs::path const& path, bool dev) -> result
+auto execute(mode mode, game game, mach mach, inst inst, fs::path const& path, bool dev, bool iw5x64) -> result
 {
-    gsc::init(game, mach, inst, dev);
+    gsc::init(game, mach, inst, dev, iw5x64);
     arc::init(game, mach, inst, dev);
 
     if (fs::is_directory(path))
@@ -1301,8 +1300,8 @@ auto main(u32 argc, char** argv) -> result
         auto mach = mach::_;
         auto inst = inst::_;
         auto dev = result["dev"].as<bool>();
+        auto const iw5x64 = result["iw5x64"].as<bool>();
         gsc::zonetool = result["zonetool"].as<bool>();
-        gsc::iw5x64 = result["iw5x64"].as<bool>();
         arc::t6fixup = result["t6fixup"].as<bool>();
         dry_run = result["dry"].as<bool>();
 
@@ -1339,7 +1338,7 @@ auto main(u32 argc, char** argv) -> result
         }
 
         std::cout << branding();
-        return execute(mode, game, mach, inst, path, dev);
+        return execute(mode, game, mach, inst, path, dev, iw5x64);
     }
     catch (std::exception const& e)
     {

--- a/test/gsc.cpp
+++ b/test/gsc.cpp
@@ -1,0 +1,22 @@
+// Copyright 2026 xensik. All rights reserved.
+//
+// Use of this source code is governed by a GNU GPLv3 license
+// that can be found in the LICENSE file.
+
+#include "xsk/stdinc.hpp"
+#include "xsk/gsc/context.hpp"
+
+#include <catch_amalgamated.hpp>
+
+using namespace xsk;
+
+TEST_CASE("iw5 pc: animation reference width", "[gsc][iw5]")
+{
+    gsc::context legacy(gsc::feature::none, gsc::engine::iw5, gsc::endian::little,
+        gsc::system::pc, gsc::instance::server, 0);
+    gsc::context x64(gsc::feature::anim4, gsc::engine::iw5, gsc::endian::little,
+        gsc::system::pc, gsc::instance::server, 0);
+
+    CHECK(legacy.opcode_size(gsc::opcode::OP_GetAnimation) == 5);
+    CHECK(x64.opcode_size(gsc::opcode::OP_GetAnimation) == 9);
+}


### PR DESCRIPTION
## Summary

This change adds opt-in support for the updated IW5 PC x64 script bytecode layout through a new `--iw5x64` command-line option.

The updated layout keeps the existing IW5 opcode table and regular string-reference widths, but stores the two references used by `OP_GetAnimation` as 32-bit values. This changes the instruction size from 5 bytes to 9 bytes. Reading these scripts with the legacy layout advances the bytecode cursor by four bytes too little and causes subsequent bytes to be interpreted as opcodes.

## Implementation

- Add a narrowly scoped `anim4` context feature for 32-bit animation references.
- Enable that feature only for the IW5 PC context when `--iw5x64` is supplied.
- Use the feature consistently in opcode sizing, assembly, and disassembly.
- Preserve the legacy IW5 PC layout by default.
- Document the new command-line option.
- Add a regression test covering both 5-byte legacy and 9-byte x64 `OP_GetAnimation` instructions.

No opcode mappings, token tables, or other engine layouts are changed.

## Usage

```text
gsc-tool -m decomp -g iw5 -s pc --iw5x64 <path>
```

Existing IW5 PC files continue to use the legacy layout when the option is omitted.

## Verification

- Release x64 build completed successfully with LLVM-MinGW.
- Test suite: 14 test cases, 35 assertions passed.
- Updated IW5 PC corpus: 60/60 script files decompiled successfully with `--iw5x64`.
- Legacy IW5 PC corpus: 42/42 script files decompiled successfully without the option.
- `git diff --check` reported no whitespace errors.
- The generated patch was verified with `git apply --check` against a clean checkout of the current development source snapshot.

The corpus files are not included in this change; they were used only for local compatibility verification.