### PR TITLE
fix(utils): harden binary IO and script asset parsing

### DIFF
--- a/include/xsk/gsc/common/asset.hpp
+++ b/include/xsk/gsc/common/asset.hpp
@@ -12,6 +12,11 @@ struct asset
 {
     using ptr = std::unique_ptr<asset>;
 
+    struct error final : public std::runtime_error
+    {
+        using std::runtime_error::runtime_error;
+    };
+
     std::string name;
     u32 compressed_length{};
     u32 length{};

--- a/include/xsk/utils/reader.hpp
+++ b/include/xsk/utils/reader.hpp
@@ -11,7 +11,11 @@ namespace xsk::utils
 struct reader
 {
     using ptr = std::unique_ptr<reader>;
-    using error = std::runtime_error;
+
+    struct error final : public std::runtime_error
+    {
+        using std::runtime_error::runtime_error;
+    };
 
 private:
     u8 const* data_;

--- a/include/xsk/utils/writer.hpp
+++ b/include/xsk/utils/writer.hpp
@@ -11,7 +11,11 @@ namespace xsk::utils
 struct writer
 {
     using ptr = std::unique_ptr<writer>;
-    using error = std::runtime_error;
+
+    struct error final : public std::runtime_error
+    {
+        using std::runtime_error::runtime_error;
+    };
 
 private:
     static constexpr usize default_size = 0x100000;

--- a/include/xsk/utils/zlib.hpp
+++ b/include/xsk/utils/zlib.hpp
@@ -10,7 +10,10 @@ namespace xsk::utils
 
 struct zlib
 {
-    using error = std::runtime_error;
+    struct error final : public std::runtime_error
+    {
+        using std::runtime_error::runtime_error;
+    };
 
     static auto compress(std::vector<u8> const& data) -> std::vector<u8>;
     static auto decompress(std::vector<u8> const& data, u32 length) -> std::vector<u8>;

--- a/src/gsc/common/asset.cpp
+++ b/src/gsc/common/asset.cpp
@@ -25,13 +25,13 @@ auto asset::serialize() const -> std::vector<u8>
     std::memcpy(&data[pos], name.data(), name.size() + 1);
     pos += name.size() + 1;
 
-    *reinterpret_cast<u32*>(&data[pos]) = compressed_length;
+    std::memcpy(data.data() + pos, &compressed_length, sizeof(compressed_length));
     pos += 4;
 
-    *reinterpret_cast<u32*>(&data[pos]) = length;
+    std::memcpy(data.data() + pos, &length, sizeof(length));
     pos += 4;
 
-    *reinterpret_cast<u32*>(&data[pos]) = bytecode_length;
+    std::memcpy(data.data() + pos, &bytecode_length, sizeof(bytecode_length));
     pos += 4;
 
     std::memcpy(&data[pos], buffer.data(), buffer.size());
@@ -44,21 +44,37 @@ auto asset::serialize() const -> std::vector<u8>
 
 auto asset::deserialize(std::vector<std::uint8_t> const& data) -> void
 {
+    constexpr auto metadata_size = usize{ 12 };
+
+    if (data.size() < metadata_size + 1)
+    {
+        throw std::runtime_error("script file deserialize error");
+    }
+
     auto pos = usize{ 0 };
 
-    name = std::string{ reinterpret_cast<char const*>(data.data()) };
+    auto const terminator = std::find(data.begin(), data.end(), u8{ 0 });
+
+    if (terminator == data.end() || static_cast<usize>(std::distance(data.begin(), terminator)) > data.size() - metadata_size - 1)
+    {
+        throw std::runtime_error("script file deserialize error");
+    }
+
+    name.assign(reinterpret_cast<char const*>(data.data()), static_cast<usize>(std::distance(data.begin(), terminator)));
     pos += name.size() + 1;
 
-    compressed_length = *reinterpret_cast<u32 const*>(data.data() + pos);
+    std::memcpy(&compressed_length, data.data() + pos, sizeof(compressed_length));
     pos += 4;
 
-    length = *reinterpret_cast<u32 const*>(data.data() + pos);
+    std::memcpy(&length, data.data() + pos, sizeof(length));
     pos += 4;
 
-    bytecode_length = *reinterpret_cast<u32 const*>(data.data() + pos);
+    std::memcpy(&bytecode_length, data.data() + pos, sizeof(bytecode_length));
     pos += 4;
 
-    if ((compressed_length + bytecode_length + name.size() + 13) != data.size())
+    auto const payload_size = data.size() - pos;
+
+    if (compressed_length > payload_size || bytecode_length != payload_size - compressed_length)
     {
         throw std::runtime_error("script file deserialize error");
     }

--- a/src/gsc/common/asset.cpp
+++ b/src/gsc/common/asset.cpp
@@ -16,7 +16,7 @@ auto asset::serialize() const -> std::vector<u8>
     // A zero compressed length marks an uncompressed stack; otherwise it stores the buffer size.
     if ((compressed_length != buffer.size() || (compressed_length == 0 && length != buffer.size())) || bytecode_length != bytecode.size())
     {
-        throw std::runtime_error("script file serialize error");
+        throw error("script file serialize error");
     }
 
     data.resize(name.size() + (compressed_length ? compressed_length : length) + bytecode_length + 13, 0);
@@ -49,17 +49,17 @@ auto asset::deserialize(std::vector<std::uint8_t> const& data) -> void
 
     if (data.size() < metadata_size + 1)
     {
-        throw std::runtime_error("script file deserialize error");
+        throw error("script file deserialize error");
     }
 
     auto pos = usize{ 0 };
 
     // The name terminator must leave all three u32 metadata fields inside the input.
-    auto const terminator = std::find(data.begin(), data.end(), u8{ 0 });
+    auto const terminator = std::ranges::find(data, u8{ 0 });
 
     if (terminator == data.end() || static_cast<usize>(std::distance(data.begin(), terminator)) > data.size() - metadata_size - 1)
     {
-        throw std::runtime_error("script file deserialize error");
+        throw error("script file deserialize error");
     }
 
     name.assign(reinterpret_cast<char const*>(data.data()), static_cast<usize>(std::distance(data.begin(), terminator)));
@@ -74,12 +74,10 @@ auto asset::deserialize(std::vector<std::uint8_t> const& data) -> void
     std::memcpy(&bytecode_length, data.data() + pos, sizeof(bytecode_length));
     pos += 4;
 
-    auto const payload_size = data.size() - pos;
-
     // The payload contains exactly the declared stack bytes followed by the bytecode bytes.
-    if (compressed_length > payload_size || bytecode_length != payload_size - compressed_length)
+    if (auto const payload_size = data.size() - pos; compressed_length > payload_size || bytecode_length != payload_size - compressed_length)
     {
-        throw std::runtime_error("script file deserialize error");
+        throw error("script file deserialize error");
     }
 
     buffer.resize(compressed_length);

--- a/src/gsc/common/asset.cpp
+++ b/src/gsc/common/asset.cpp
@@ -13,6 +13,7 @@ auto asset::serialize() const -> std::vector<u8>
 {
     auto data = std::vector<u8>{};
 
+    // A zero compressed length marks an uncompressed stack; otherwise it stores the buffer size.
     if ((compressed_length != buffer.size() || (compressed_length == 0 && length != buffer.size())) || bytecode_length != bytecode.size())
     {
         throw std::runtime_error("script file serialize error");
@@ -53,6 +54,7 @@ auto asset::deserialize(std::vector<std::uint8_t> const& data) -> void
 
     auto pos = usize{ 0 };
 
+    // The name terminator must leave all three u32 metadata fields inside the input.
     auto const terminator = std::find(data.begin(), data.end(), u8{ 0 });
 
     if (terminator == data.end() || static_cast<usize>(std::distance(data.begin(), terminator)) > data.size() - metadata_size - 1)
@@ -74,6 +76,7 @@ auto asset::deserialize(std::vector<std::uint8_t> const& data) -> void
 
     auto const payload_size = data.size() - pos;
 
+    // The payload contains exactly the declared stack bytes followed by the bytecode bytes.
     if (compressed_length > payload_size || bytecode_length != payload_size - compressed_length)
     {
         throw std::runtime_error("script file deserialize error");

--- a/src/utils/reader.cpp
+++ b/src/utils/reader.cpp
@@ -9,6 +9,29 @@
 namespace xsk::utils
 {
 
+namespace
+{
+
+template <typename T>
+auto read_scalar(u8 const* data, const usize size, usize& pos, const bool swap) -> T
+{
+    if (pos > size || sizeof(T) > size - pos)
+        throw reader::error("reader: out of bounds");
+
+    auto bytes = std::array<u8, sizeof(T)>{};
+    std::memcpy(bytes.data(), data + pos, sizeof(T));
+
+    if (swap)
+        std::reverse(bytes.begin(), bytes.end());
+
+    auto value = T{};
+    std::memcpy(&value, bytes.data(), sizeof(T));
+    pos += sizeof(T);
+    return value;
+}
+
+} // namespace
+
 reader::reader(const bool swap) : data_{ nullptr }, size_{ 0 }, swap_{ swap }
 {
 }
@@ -24,219 +47,101 @@ reader::reader(u8 const* data, const usize size, const bool swap) : data_{ data 
 template <>
 auto reader::read() -> i8
 {
-    if (pos_ + 1 > size_)
-        throw error("reader: out of bounds");
-
-    auto const value = *reinterpret_cast<i8 const*>(data_ + pos_);
-    pos_ += 1;
-    return value;
+    return read_scalar<i8>(data_, size_, pos_, false);
 }
 
 template <>
 auto reader::read() -> u8
 {
-    if (pos_ + 1 > size_)
-        throw error("reader: out of bounds");
-
-    auto const value = *reinterpret_cast<u8 const*>(data_ + pos_);
-    pos_ += 1;
-    return value;
+    return read_scalar<u8>(data_, size_, pos_, false);
 }
 
 template <>
 auto reader::read() -> i16
 {
-    if (pos_ + 2 > size_)
-        throw error("reader: out of bounds");
-
-    if (!swap_)
-    {
-        auto const value = *reinterpret_cast<i16 const*>(data_ + pos_);
-        pos_ += 2;
-        return value;
-    }
-
-    auto bytes = std::array<u8, 2>{};
-    bytes[0] = (data_ + pos_)[1];
-    bytes[1] = (data_ + pos_)[0];
-    pos_ += 2;
-    return *reinterpret_cast<i16*>(bytes.data());
+    return read_scalar<i16>(data_, size_, pos_, swap_);
 }
 
 template <>
 auto reader::read() -> u16
 {
-    if (pos_ + 2 > size_)
-        throw error("reader: out of bounds");
-
-    if (!swap_)
-    {
-        auto const value = *reinterpret_cast<u16 const*>(data_ + pos_);
-        pos_ += 2;
-        return value;
-    }
-
-    auto bytes = std::array<u8, 2>{};
-    bytes[0] = (data_ + pos_)[1];
-    bytes[1] = (data_ + pos_)[0];
-    pos_ += 2;
-    return *reinterpret_cast<u16*>(bytes.data());
+    return read_scalar<u16>(data_, size_, pos_, swap_);
 }
 
 template <>
 auto reader::read() -> i32
 {
-    if (pos_ + 4 > size_)
-        throw error("reader: out of bounds");
-
-    if (!swap_)
-    {
-        auto const value = *reinterpret_cast<i32 const*>(data_ + pos_);
-        pos_ += 4;
-        return value;
-    }
-
-    auto bytes = std::array<u8, 4>{};
-    bytes[0] = (data_ + pos_)[3];
-    bytes[1] = (data_ + pos_)[2];
-    bytes[2] = (data_ + pos_)[1];
-    bytes[3] = (data_ + pos_)[0];
-    pos_ += 4;
-    return *reinterpret_cast<i32*>(bytes.data());
+    return read_scalar<i32>(data_, size_, pos_, swap_);
 }
 
 template <>
 auto reader::read() -> u32
 {
-    if (pos_ + 4 > size_)
-        throw error("reader: out of bounds");
-
-    if (!swap_)
-    {
-        auto const value = *reinterpret_cast<u32 const*>(data_ + pos_);
-        pos_ += 4;
-        return value;
-    }
-
-    auto bytes = std::array<u8, 4>{};
-    bytes[0] = (data_ + pos_)[3];
-    bytes[1] = (data_ + pos_)[2];
-    bytes[2] = (data_ + pos_)[1];
-    bytes[3] = (data_ + pos_)[0];
-    pos_ += 4;
-    return *reinterpret_cast<u32*>(bytes.data());
+    return read_scalar<u32>(data_, size_, pos_, swap_);
 }
 
 template <>
 auto reader::read() -> i64
 {
-    if (pos_ + 8 > size_)
-        throw error("reader: out of bounds");
-
-    if (!swap_)
-    {
-        auto const value = *reinterpret_cast<i64 const*>(data_ + pos_);
-        pos_ += 8;
-        return value;
-    }
-
-    auto bytes = std::array<u8, 8>{};
-    bytes[0] = (data_ + pos_)[7];
-    bytes[1] = (data_ + pos_)[6];
-    bytes[2] = (data_ + pos_)[5];
-    bytes[3] = (data_ + pos_)[4];
-    bytes[4] = (data_ + pos_)[3];
-    bytes[5] = (data_ + pos_)[2];
-    bytes[6] = (data_ + pos_)[1];
-    bytes[7] = (data_ + pos_)[0];
-    pos_ += 8;
-    return *reinterpret_cast<i64*>(bytes.data());
+    return read_scalar<i64>(data_, size_, pos_, swap_);
 }
 
 template <>
 auto reader::read() -> u64
 {
-    if (pos_ + 8 > size_)
-        throw error("reader: out of bounds");
-
-    if (!swap_)
-    {
-        auto const value = *reinterpret_cast<u64 const*>(data_ + pos_);
-        pos_ += 8;
-        return value;
-    }
-
-    auto bytes = std::array<u8, 8>{};
-    bytes[0] = (data_ + pos_)[7];
-    bytes[1] = (data_ + pos_)[6];
-    bytes[2] = (data_ + pos_)[5];
-    bytes[3] = (data_ + pos_)[4];
-    bytes[4] = (data_ + pos_)[3];
-    bytes[5] = (data_ + pos_)[2];
-    bytes[6] = (data_ + pos_)[1];
-    bytes[7] = (data_ + pos_)[0];
-    pos_ += 8;
-    return *reinterpret_cast<u64*>(bytes.data());
+    return read_scalar<u64>(data_, size_, pos_, swap_);
 }
 
 template <>
 auto reader::read() -> f32
 {
-    if (pos_ + 4 > size_)
-        throw error("reader: out of bounds");
-
-    if (!swap_)
-    {
-        auto const value = *reinterpret_cast<f32 const*>(data_ + pos_);
-        pos_ += 4;
-        return value;
-    }
-
-    auto bytes = std::array<u8, 4>{};
-    bytes[0] = (data_ + pos_)[3];
-    bytes[1] = (data_ + pos_)[2];
-    bytes[2] = (data_ + pos_)[1];
-    bytes[3] = (data_ + pos_)[0];
-    pos_ += 4;
-    return *reinterpret_cast<f32*>(bytes.data());
+    return read_scalar<f32>(data_, size_, pos_, swap_);
 }
 
 auto reader::read_i24() -> i32
 {
-    if (pos_ + 3 > size_)
+    if (pos_ > size_ || 3 > size_ - pos_)
         throw error("reader: out of bounds");
 
-    if (!swap_)
-    {
-        auto const value = *reinterpret_cast<i32 const*>(data_ + pos_) & 0xFFFFFF;
-        pos_ += 3;
-        return value;
-    }
-
-    auto bytes = std::array<u8, 4>{};
-    bytes[0] = (data_ + pos_)[2];
-    bytes[1] = (data_ + pos_)[1];
-    bytes[2] = (data_ + pos_)[0];
+    auto const value = !swap_
+                           ? static_cast<u32>(data_[pos_]) | (static_cast<u32>(data_[pos_ + 1]) << 8) | (static_cast<u32>(data_[pos_ + 2]) << 16)
+                           : static_cast<u32>(data_[pos_ + 2]) | (static_cast<u32>(data_[pos_ + 1]) << 8) | (static_cast<u32>(data_[pos_]) << 16);
     pos_ += 3;
-    return *reinterpret_cast<i32*>(bytes.data());
+    return static_cast<i32>(value);
 }
 
 auto reader::read_cstr() -> std::string
 {
-    auto ret = std::string{ reinterpret_cast<char const*>(data_ + pos_) };
-    pos_ += static_cast<u32>(ret.size() + 1);
+    if (pos_ > size_)
+        throw error("reader: out of bounds");
+
+    auto const begin = data_ + pos_;
+    auto const end = data_ + size_;
+    auto const terminator = std::find(begin, end, 0);
+
+    if (terminator == end)
+        throw error("reader: out of bounds");
+
+    auto ret = std::string(reinterpret_cast<char const*>(begin), static_cast<usize>(terminator - begin));
+    pos_ += ret.size() + 1;
     return ret;
 }
 
 auto reader::read_bytes(const usize pos, const usize count) const -> std::string
 {
+    if (pos > size_ || count > size_ - pos)
+        throw error("reader: out of bounds");
+
+    if (count == 0)
+        return {};
+
     auto data = std::string{};
 
     data.reserve(count * 3);
 
-    for (auto i = pos; i < pos + count; i++)
+    for (auto i = usize{}; i < count; i++)
     {
-        std::format_to(std::back_insert_iterator(data), "{:02X} ", *reinterpret_cast<u8 const*>(data_ + i));
+        std::format_to(std::back_insert_iterator(data), "{:02X} ", data_[pos + i]);
     }
 
     data.pop_back();
@@ -251,7 +156,7 @@ auto reader::is_avail() const -> bool
 
 auto reader::seek(const usize size) -> void
 {
-    if (pos_ + size <= size_) pos_ += size;
+    if (pos_ <= size_ && size <= size_ - pos_) pos_ += size;
 }
 
 auto reader::seek_neg(const usize size) -> void
@@ -261,9 +166,17 @@ auto reader::seek_neg(const usize size) -> void
 
 auto reader::align(const usize size) -> usize
 {
-    auto const pos = pos_;
+    if (size == 0 || (size & (size - 1)) != 0)
+        throw error("reader: invalid alignment");
 
-    pos_ = (pos_ + (size - 1)) & ~(size - 1);
+    auto const pos = pos_;
+    auto const remainder = pos_ & (size - 1);
+    auto const advance = remainder == 0 ? 0 : size - remainder;
+
+    if (pos_ > size_ || advance > size_ - pos_)
+        throw error("reader: out of bounds");
+
+    pos_ += advance;
 
     return pos_ - pos;
 }

--- a/src/utils/reader.cpp
+++ b/src/utils/reader.cpp
@@ -6,6 +6,8 @@
 #include "xsk/stdinc.hpp"
 #include "xsk/utils/reader.hpp"
 
+#include <bit>
+
 namespace xsk::utils
 {
 
@@ -23,7 +25,7 @@ auto read_scalar(u8 const* data, const usize size, usize& pos, const bool swap) 
     std::memcpy(bytes.data(), data + pos, sizeof(T));
 
     if (swap)
-        std::reverse(bytes.begin(), bytes.end());
+        std::ranges::reverse(bytes);
 
     auto value = T{};
     std::memcpy(&value, bytes.data(), sizeof(T));
@@ -167,7 +169,7 @@ auto reader::seek_neg(const usize size) -> void
 
 auto reader::align(const usize size) -> usize
 {
-    if (size == 0 || (size & (size - 1)) != 0)
+    if (!std::has_single_bit(size))
         throw error("reader: invalid alignment");
 
     auto const pos = pos_;

--- a/src/utils/reader.cpp
+++ b/src/utils/reader.cpp
@@ -18,6 +18,7 @@ auto read_scalar(u8 const* data, const usize size, usize& pos, const bool swap) 
     if (pos > size || sizeof(T) > size - pos)
         throw reader::error("reader: out of bounds");
 
+    // Copy through bytes so packed fields do not rely on typed pointer alignment or aliasing.
     auto bytes = std::array<u8, sizeof(T)>{};
     std::memcpy(bytes.data(), data + pos, sizeof(T));
 

--- a/src/utils/writer.cpp
+++ b/src/utils/writer.cpp
@@ -9,6 +9,27 @@
 namespace xsk::utils
 {
 
+namespace
+{
+
+template <typename T>
+auto write_scalar(u8* output, const usize size, usize& pos, T value, const bool swap) -> void
+{
+    if (pos > size || sizeof(T) > size - pos)
+        throw writer::error("writer: out of bounds");
+
+    auto bytes = std::array<u8, sizeof(T)>{};
+    std::memcpy(bytes.data(), &value, sizeof(T));
+
+    if (swap)
+        std::reverse(bytes.begin(), bytes.end());
+
+    std::memcpy(output + pos, bytes.data(), sizeof(T));
+    pos += sizeof(T);
+}
+
+} // namespace
+
 writer::writer(const bool swap) : size_{ default_size }, swap_{ swap }
 {
     data_ = new u8[size_]();
@@ -33,196 +54,73 @@ auto writer::clear() -> void
 template <>
 auto writer::write(const i8 data) -> void
 {
-    if (pos_ + 1 > size_)
-        throw error("writer: out of bounds");
-
-    *reinterpret_cast<i8*>(data_ + pos_) = data;
-    pos_ += 1;
+    write_scalar(data_, size_, pos_, data, false);
 }
 
 template <>
 auto writer::write(const u8 data) -> void
 {
-    if (pos_ + 1 > size_)
-        throw error("writer: out of bounds");
-
-    *reinterpret_cast<u8*>(data_ + pos_) = data;
-    pos_ += 1;
+    write_scalar(data_, size_, pos_, data, false);
 }
 
 template <>
 auto writer::write(i16 data) -> void
 {
-    if (pos_ + 2 > size_)
-        throw error("writer: out of bounds");
-
-    if (!swap_)
-    {
-        *reinterpret_cast<i16*>(data_ + pos_) = data;
-    }
-    else
-    {
-        (data_ + pos_)[0] = reinterpret_cast<u8*>(&data)[1];
-        (data_ + pos_)[1] = reinterpret_cast<u8*>(&data)[0];
-    }
-
-    pos_ += 2;
+    write_scalar(data_, size_, pos_, data, swap_);
 }
 
 template <>
 auto writer::write(u16 data) -> void
 {
-    if (pos_ + 2 > size_)
-        throw error("writer: out of bounds");
-
-    if (!swap_)
-    {
-        *reinterpret_cast<u16*>(data_ + pos_) = data;
-    }
-    else
-    {
-        (data_ + pos_)[0] = reinterpret_cast<u8*>(&data)[1];
-        (data_ + pos_)[1] = reinterpret_cast<u8*>(&data)[0];
-    }
-
-    pos_ += 2;
+    write_scalar(data_, size_, pos_, data, swap_);
 }
 
 template <>
 auto writer::write(i32 data) -> void
 {
-    if (pos_ + 4 > size_)
-        throw error("writer: out of bounds");
-
-    if (!swap_)
-    {
-        *reinterpret_cast<i32*>(data_ + pos_) = data;
-    }
-    else
-    {
-        (data_ + pos_)[0] = reinterpret_cast<u8*>(&data)[3];
-        (data_ + pos_)[1] = reinterpret_cast<u8*>(&data)[2];
-        (data_ + pos_)[2] = reinterpret_cast<u8*>(&data)[1];
-        (data_ + pos_)[3] = reinterpret_cast<u8*>(&data)[0];
-    }
-
-    pos_ += 4;
+    write_scalar(data_, size_, pos_, data, swap_);
 }
 
 template <>
 auto writer::write(u32 data) -> void
 {
-    if (pos_ + 4 > size_)
-        throw error("writer: out of bounds");
-
-    if (!swap_)
-    {
-        *reinterpret_cast<u32*>(data_ + pos_) = data;
-    }
-    else
-    {
-        (data_ + pos_)[0] = reinterpret_cast<u8*>(&data)[3];
-        (data_ + pos_)[1] = reinterpret_cast<u8*>(&data)[2];
-        (data_ + pos_)[2] = reinterpret_cast<u8*>(&data)[1];
-        (data_ + pos_)[3] = reinterpret_cast<u8*>(&data)[0];
-    }
-
-    pos_ += 4;
+    write_scalar(data_, size_, pos_, data, swap_);
 }
 
 template <>
 auto writer::write(i64 data) -> void
 {
-    if (pos_ + 8 > size_)
-        throw error("writer: out of bounds");
-
-    if (!swap_)
-    {
-        *reinterpret_cast<i64*>(data_ + pos_) = data;
-    }
-    else
-    {
-        (data_ + pos_)[0] = reinterpret_cast<u8*>(&data)[7];
-        (data_ + pos_)[1] = reinterpret_cast<u8*>(&data)[6];
-        (data_ + pos_)[2] = reinterpret_cast<u8*>(&data)[5];
-        (data_ + pos_)[3] = reinterpret_cast<u8*>(&data)[4];
-        (data_ + pos_)[4] = reinterpret_cast<u8*>(&data)[3];
-        (data_ + pos_)[5] = reinterpret_cast<u8*>(&data)[2];
-        (data_ + pos_)[6] = reinterpret_cast<u8*>(&data)[1];
-        (data_ + pos_)[7] = reinterpret_cast<u8*>(&data)[0];
-    }
-
-    pos_ += 8;
+    write_scalar(data_, size_, pos_, data, swap_);
 }
 
 template <>
 auto writer::write(u64 data) -> void
 {
-    if (pos_ + 8 > size_)
-        throw error("writer: out of bounds");
-
-    if (!swap_)
-    {
-        *reinterpret_cast<u64*>(data_ + pos_) = data;
-    }
-    else
-    {
-        (data_ + pos_)[0] = reinterpret_cast<u8*>(&data)[7];
-        (data_ + pos_)[1] = reinterpret_cast<u8*>(&data)[6];
-        (data_ + pos_)[2] = reinterpret_cast<u8*>(&data)[5];
-        (data_ + pos_)[3] = reinterpret_cast<u8*>(&data)[4];
-        (data_ + pos_)[4] = reinterpret_cast<u8*>(&data)[3];
-        (data_ + pos_)[5] = reinterpret_cast<u8*>(&data)[2];
-        (data_ + pos_)[6] = reinterpret_cast<u8*>(&data)[1];
-        (data_ + pos_)[7] = reinterpret_cast<u8*>(&data)[0];
-    }
-
-    pos_ += 8;
+    write_scalar(data_, size_, pos_, data, swap_);
 }
 
 template <>
 auto writer::write(f32 data) -> void
 {
-    if (pos_ + 4 > size_)
-        throw error("writer: out of bounds");
-
-    if (!swap_)
-    {
-        *reinterpret_cast<f32*>(data_ + pos_) = data;
-    }
-    else
-    {
-        (data_ + pos_)[0] = reinterpret_cast<u8*>(&data)[3];
-        (data_ + pos_)[1] = reinterpret_cast<u8*>(&data)[2];
-        (data_ + pos_)[2] = reinterpret_cast<u8*>(&data)[1];
-        (data_ + pos_)[3] = reinterpret_cast<u8*>(&data)[0];
-    }
-
-    pos_ += 4;
+    write_scalar(data_, size_, pos_, data, swap_);
 }
 
 auto writer::write_i24(i32 data) -> void
 {
-    if (pos_ + 3 > size_)
+    if (pos_ > size_ || 3 > size_ - pos_)
         throw error("writer: out of bounds");
 
-    if (!swap_)
-    {
-        *reinterpret_cast<i32*>(data_ + pos_) = data & 0xFFFFFF;
-    }
-    else
-    {
-        (data_ + pos_)[0] = reinterpret_cast<u8*>(&data)[2];
-        (data_ + pos_)[1] = reinterpret_cast<u8*>(&data)[1];
-        (data_ + pos_)[2] = reinterpret_cast<u8*>(&data)[0];
-    }
+    auto const value = static_cast<u32>(data) & 0xFFFFFF;
+    data_[pos_] = static_cast<u8>(swap_ ? value >> 16 : value);
+    data_[pos_ + 1] = static_cast<u8>(value >> 8);
+    data_[pos_ + 2] = static_cast<u8>(swap_ ? value : value >> 16);
 
     pos_ += 3;
 }
 
 auto writer::write_string(std::string const& data) -> void
 {
-    if (pos_ + data.size() > size_)
+    if (pos_ > size_ || data.size() > size_ - pos_)
         throw error("writer: out of bounds");
 
     std::memcpy(reinterpret_cast<void*>(data_ + pos_), data.data(), data.size());
@@ -231,10 +129,11 @@ auto writer::write_string(std::string const& data) -> void
 
 auto writer::write_cstr(std::string const& data) -> void
 {
-    if (pos_ + data.size() >= size_)
+    if (pos_ > size_ || data.size() >= size_ - pos_)
         throw error("writer: out of bounds");
 
     std::memcpy(reinterpret_cast<void*>(data_ + pos_), data.data(), data.size());
+    data_[pos_ + data.size()] = 0;
     pos_ += data.size() + 1;
 }
 
@@ -245,7 +144,7 @@ auto writer::is_avail() const -> bool
 
 auto writer::seek(const usize size) -> void
 {
-    if (pos_ + size <= size_) pos_ += size;
+    if (pos_ <= size_ && size <= size_ - pos_) pos_ += size;
 }
 
 auto writer::seek_neg(const usize size) -> void
@@ -255,9 +154,17 @@ auto writer::seek_neg(const usize size) -> void
 
 auto writer::align(const usize size) -> usize
 {
-    auto const pos = pos_;
+    if (size == 0 || (size & (size - 1)) != 0)
+        throw error("writer: invalid alignment");
 
-    pos_ = (pos_ + (size - 1)) & ~(size - 1);
+    auto const pos = pos_;
+    auto const remainder = pos_ & (size - 1);
+    auto const advance = remainder == 0 ? 0 : size - remainder;
+
+    if (pos_ > size_ || advance > size_ - pos_)
+        throw error("writer: out of bounds");
+
+    pos_ += advance;
 
     return pos_ - pos;
 }

--- a/src/utils/writer.cpp
+++ b/src/utils/writer.cpp
@@ -18,6 +18,7 @@ auto write_scalar(u8* output, const usize size, usize& pos, T value, const bool 
     if (pos > size || sizeof(T) > size - pos)
         throw writer::error("writer: out of bounds");
 
+    // Copy through bytes so packed fields do not rely on typed pointer alignment or aliasing.
     auto bytes = std::array<u8, sizeof(T)>{};
     std::memcpy(bytes.data(), &value, sizeof(T));
 

--- a/src/utils/writer.cpp
+++ b/src/utils/writer.cpp
@@ -6,6 +6,8 @@
 #include "xsk/stdinc.hpp"
 #include "xsk/utils/writer.hpp"
 
+#include <bit>
+
 namespace xsk::utils
 {
 
@@ -23,7 +25,7 @@ auto write_scalar(u8* output, const usize size, usize& pos, T value, const bool 
     std::memcpy(bytes.data(), &value, sizeof(T));
 
     if (swap)
-        std::reverse(bytes.begin(), bytes.end());
+        std::ranges::reverse(bytes);
 
     std::memcpy(output + pos, bytes.data(), sizeof(T));
     pos += sizeof(T);
@@ -155,7 +157,7 @@ auto writer::seek_neg(const usize size) -> void
 
 auto writer::align(const usize size) -> usize
 {
-    if (size == 0 || (size & (size - 1)) != 0)
+    if (!std::has_single_bit(size))
         throw error("writer: invalid alignment");
 
     auto const pos = pos_;

--- a/src/utils/zlib.cpp
+++ b/src/utils/zlib.cpp
@@ -30,6 +30,7 @@ auto zlib::compress(std::vector<u8> const& data) -> std::vector<u8>
 
 auto zlib::decompress(std::vector<u8> const& data, const u32 length) -> std::vector<u8>
 {
+    // Stream into fixed chunks and reject corrupt script lengths before allocating them.
     constexpr auto chunk_size = usize{ 64 * 1024 };
     constexpr auto max_output_size = usize{ 256 * 1024 * 1024 };
 

--- a/src/utils/zlib.cpp
+++ b/src/utils/zlib.cpp
@@ -5,6 +5,9 @@
 
 #include "xsk/stdinc.hpp"
 #include "xsk/utils/zlib.hpp"
+
+// Request zlib's const-correct input pointer declaration.
+#define ZLIB_CONST
 #include "zlib.h"
 
 namespace xsk::utils
@@ -32,13 +35,12 @@ auto zlib::decompress(std::vector<u8> const& data, const u32 length) -> std::vec
 {
     // Stream into fixed chunks and reject corrupt script lengths before allocating them.
     constexpr auto chunk_size = usize{ 64 * 1024 };
-    constexpr auto max_output_size = usize{ 256 * 1024 * 1024 };
 
-    if (length > max_output_size || data.size() > std::numeric_limits<uInt>::max())
+    if (constexpr auto max_output_size = usize{ 256 * 1024 * 1024 }; length > max_output_size || data.size() > std::numeric_limits<uInt>::max())
         throw error("zlib decompress error: size limit exceeded");
 
     auto stream = z_stream{};
-    stream.next_in = const_cast<Bytef*>(reinterpret_cast<Bytef const*>(data.data()));
+    stream.next_in = reinterpret_cast<Bytef const*>(data.data());
     stream.avail_in = static_cast<uInt>(data.size());
 
     auto result = inflateInit(&stream);

--- a/src/utils/zlib.cpp
+++ b/src/utils/zlib.cpp
@@ -30,20 +30,55 @@ auto zlib::compress(std::vector<u8> const& data) -> std::vector<u8>
 
 auto zlib::decompress(std::vector<u8> const& data, const u32 length) -> std::vector<u8>
 {
+    constexpr auto chunk_size = usize{ 64 * 1024 };
+    constexpr auto max_output_size = usize{ 256 * 1024 * 1024 };
+
+    if (length > max_output_size || data.size() > std::numeric_limits<uInt>::max())
+        throw error("zlib decompress error: size limit exceeded");
+
+    auto stream = z_stream{};
+    stream.next_in = const_cast<Bytef*>(reinterpret_cast<Bytef const*>(data.data()));
+    stream.avail_in = static_cast<uInt>(data.size());
+
+    auto result = inflateInit(&stream);
+    if (result != Z_OK)
+        throw error(std::format("zlib decompress init error {}", result));
+
     auto output = std::vector<u8>{};
-    output.resize(length);
+    output.reserve(std::min<usize>(length, chunk_size));
+    auto chunk = std::array<u8, chunk_size>{};
 
-    // uLongf is 64-bit on LP64, do not alias it over a u32
-    auto size = static_cast<uLongf>(length);
-    auto result = uncompress(reinterpret_cast<Bytef*>(output.data()), &size, reinterpret_cast<const Bytef*>(data.data()), static_cast<uLong>(data.size()));
-
-    if (result == Z_OK)
+    while (true)
     {
-        output.resize(size);
-        return output;
+        stream.next_out = reinterpret_cast<Bytef*>(chunk.data());
+        stream.avail_out = static_cast<uInt>(chunk.size());
+        result = inflate(&stream, Z_NO_FLUSH);
+
+        auto const produced = chunk.size() - stream.avail_out;
+        if (produced > static_cast<usize>(length) - output.size())
+        {
+            inflateEnd(&stream);
+            throw error("zlib decompress error: output exceeds expected length");
+        }
+
+        output.insert(output.end(), chunk.begin(), chunk.begin() + produced);
+
+        if (result == Z_STREAM_END)
+            break;
+
+        if (result != Z_OK || (produced == 0 && stream.avail_in == 0))
+        {
+            inflateEnd(&stream);
+            throw error(std::format("zlib decompress error {}", result));
+        }
     }
 
-    throw error(std::format("zlib decompress error {}", result));
+    inflateEnd(&stream);
+
+    if (output.size() != length)
+        throw error("zlib decompress error: output length mismatch");
+
+    return output;
 }
 
 } // namespace xsk::utils

--- a/test/utils.cpp
+++ b/test/utils.cpp
@@ -4,6 +4,7 @@
 // that can be found in the LICENSE file.
 
 #include "xsk/stdinc.hpp"
+#include "xsk/gsc/common/asset.hpp"
 #include "xsk/utils/reader.hpp"
 #include "xsk/utils/writer.hpp"
 #include "xsk/utils/zlib.hpp"
@@ -173,6 +174,16 @@ TEST_CASE("zlib: empty data", "[utils][zlib]")
     REQUIRE(decompressed.empty());
 }
 
+TEST_CASE("zlib: declared output length is validated without oversized allocation", "[utils][zlib]")
+{
+    auto const input = std::vector<u8>{ 't', 'e', 's', 't' };
+    auto const compressed = zlib::compress(input);
+
+    CHECK(zlib::decompress(compressed, static_cast<u32>(input.size())) == input);
+    CHECK_THROWS_AS(zlib::decompress(compressed, static_cast<u32>(input.size() + 1)), std::runtime_error);
+    CHECK_THROWS_AS(zlib::decompress(compressed, std::numeric_limits<u32>::max()), std::runtime_error);
+}
+
 TEST_CASE("reader: unaligned scalar reads are supported", "[utils][reader]")
 {
     auto const data = std::vector<u8>{ 0xFF, 0x34, 0x12, 0x78, 0x56, 0x34, 0x12 };
@@ -241,6 +252,47 @@ TEST_CASE("writer: cstr terminates overwritten data and validates alignment", "[
     CHECK(output.data()[1] == 0);
     CHECK_THROWS_AS(output.align(0), std::runtime_error);
     CHECK_THROWS_AS(output.align(3), std::runtime_error);
+}
+
+TEST_CASE("gsc asset: malformed input is rejected", "[gsc][asset]")
+{
+    auto value = gsc::asset{};
+
+    CHECK_THROWS_AS(value.deserialize({}), std::runtime_error);
+    CHECK_THROWS_AS(value.deserialize(std::vector<u8>(13, 1)), std::runtime_error);
+    CHECK_THROWS_AS(value.deserialize({ 'a', 0 }), std::runtime_error);
+}
+
+TEST_CASE("gsc asset: empty payload is accepted", "[gsc][asset]")
+{
+    auto value = gsc::asset{};
+    auto data = std::vector<u8>(13, 0);
+
+    CHECK_NOTHROW(value.deserialize(data));
+    CHECK(value.name.empty());
+    CHECK(value.buffer.empty());
+    CHECK(value.bytecode.empty());
+}
+
+TEST_CASE("gsc asset: serialization round-trip preserves metadata and payload", "[gsc][asset]")
+{
+    auto original = gsc::asset{};
+    original.name = "test";
+    original.buffer = { 1, 2, 3 };
+    original.bytecode = { 4, 5 };
+    original.compressed_length = static_cast<u32>(original.buffer.size());
+    original.length = 7;
+    original.bytecode_length = static_cast<u32>(original.bytecode.size());
+
+    auto restored = gsc::asset{};
+    restored.deserialize(original.serialize());
+
+    CHECK(restored.name == original.name);
+    CHECK(restored.compressed_length == original.compressed_length);
+    CHECK(restored.length == original.length);
+    CHECK(restored.bytecode_length == original.bytecode_length);
+    CHECK(restored.buffer == original.buffer);
+    CHECK(restored.bytecode == original.bytecode);
 }
 
 } // namespace xsk::test

--- a/test/utils.cpp
+++ b/test/utils.cpp
@@ -173,4 +173,74 @@ TEST_CASE("zlib: empty data", "[utils][zlib]")
     REQUIRE(decompressed.empty());
 }
 
+TEST_CASE("reader: unaligned scalar reads are supported", "[utils][reader]")
+{
+    auto const data = std::vector<u8>{ 0xFF, 0x34, 0x12, 0x78, 0x56, 0x34, 0x12 };
+    auto value = reader{ data };
+
+    value.seek(1);
+    CHECK(value.read<u16>() == 0x1234);
+    CHECK(value.read<u32>() == 0x12345678);
+}
+
+TEST_CASE("reader: i24 does not read beyond its three bytes", "[utils][reader]")
+{
+    auto const data = std::vector<u8>{ 0x56, 0x34, 0x12 };
+    auto little = reader{ data };
+    auto big = reader{ data, true };
+
+    CHECK(little.read_i24() == 0x123456);
+    CHECK(big.read_i24() == 0x563412);
+    CHECK(little.pos() == 3);
+}
+
+TEST_CASE("reader: malformed ranges and strings are rejected", "[utils][reader]")
+{
+    auto const data = std::vector<u8>{ 'a', 'b', 'c' };
+    auto value = reader{ data };
+
+    CHECK_THROWS_AS(value.read_cstr(), std::runtime_error);
+    CHECK(value.read_bytes(0, 0).empty());
+    CHECK_THROWS_AS(value.read_bytes(2, 2), std::runtime_error);
+    CHECK_THROWS_AS(value.align(0), std::runtime_error);
+    CHECK_THROWS_AS(value.align(3), std::runtime_error);
+}
+
+TEST_CASE("writer: unaligned scalar writes round-trip through reader", "[utils][writer]")
+{
+    auto output = writer{ usize{ 7 } };
+    output.write<u8>(0xFF);
+    output.write<u16>(0x1234);
+    output.write<u32>(0x12345678);
+
+    auto input = reader{ output.data(), output.pos() };
+    CHECK(input.read<u8>() == 0xFF);
+    CHECK(input.read<u16>() == 0x1234);
+    CHECK(input.read<u32>() == 0x12345678);
+}
+
+TEST_CASE("writer: i24 writes exactly three bytes", "[utils][writer]")
+{
+    auto output = writer{ usize{ 3 } };
+    output.write_i24(0x123456);
+
+    CHECK(output.pos() == 3);
+    CHECK(output.data()[0] == 0x56);
+    CHECK(output.data()[1] == 0x34);
+    CHECK(output.data()[2] == 0x12);
+}
+
+TEST_CASE("writer: cstr terminates overwritten data and validates alignment", "[utils][writer]")
+{
+    auto output = writer{ usize{ 4 } };
+    output.write_string("xxxx");
+    output.pos(0);
+    output.write_cstr("a");
+
+    CHECK(output.data()[0] == 'a');
+    CHECK(output.data()[1] == 0);
+    CHECK_THROWS_AS(output.align(0), std::runtime_error);
+    CHECK_THROWS_AS(output.align(3), std::runtime_error);
+}
+
 } // namespace xsk::test


### PR DESCRIPTION
## Summary

- replace alignment-dependent scalar reads and writes with safe byte copies
- make 24-bit reads and writes access exactly three bytes
- reject invalid ranges, unterminated strings, and invalid alignment requests
- validate serialized script-asset boundaries before copying payloads
- decompress zlib data incrementally with an explicit output-size limit
- add regression tests for malformed input and serialization round trips

## Why the diff removes many lines

No public APIs, supported formats, or scalar specializations are removed. The previous reader and writer repeated the same pointer-based access logic for every scalar type. This PR consolidates that duplication into `read_scalar` and `write_scalar`, while preserving byte-order handling and the existing type-specific entry points. The shared implementation is smaller and also avoids alignment and aliasing assumptions.

## Validation

- release x64: 70 assertions in 23 test cases passed
- release x86: 70 assertions in 23 test cases passed
- combined with #283: 72 assertions in 24 test cases passed
- no changed files overlap with #283; Git merges both branches cleanly in either order

## Scope

This PR is based directly on `dev`. It is independent of #283 and can be merged before or after it.