### PR TITLE
fix(iw5): match xenon vector bytecode padding

### DIFF
--- a/src/gsc/assembler.cpp
+++ b/src/gsc/assembler.cpp
@@ -177,7 +177,26 @@ auto assembler::assemble_instruction(instruction const& inst) -> void
             script_.write<f32>(std::stof(inst.data[0]));
             break;
         case opcode::OP_GetVector:
-            script_.align(ctx_->endian() == endian::little ? 1 : 4);
+            if (ctx_->engine() == engine::iw5 && ctx_->system() == system::xb2)
+            {
+                // When padding is required, stock IW5 Xenon bytecode uses OP_GetVector as the final
+                // alignment byte before the vector payload. Match that retail encoding.
+                auto const padding = (4 - (script_.pos() & 3)) & 3;
+
+                for (usize i = 1; i < padding; ++i)
+                {
+                    script_.write<u8>(0);
+                }
+
+                if (padding)
+                {
+                    script_.write<u8>(ctx_->opcode_id(inst.opcode));
+                }
+            }
+            else
+            {
+                script_.align(ctx_->endian() == endian::little ? 1 : 4);
+            }
             script_.write<f32>(std::stof(inst.data[0]));
             script_.write<f32>(std::stof(inst.data[1]));
             script_.write<f32>(std::stof(inst.data[2]));

--- a/test/gsc_assembler.cpp
+++ b/test/gsc_assembler.cpp
@@ -1,0 +1,50 @@
+// Copyright 2026 xensik. All rights reserved.
+//
+// Use of this source code is governed by a GNU GPLv3 license
+// that can be found in the LICENSE file.
+
+#include "xsk/stdinc.hpp"
+#include "xsk/gsc/engine/iw5_xb.hpp"
+#include <catch_amalgamated.hpp>
+
+namespace xsk::test
+{
+
+using namespace xsk::gsc;
+
+TEST_CASE("IW5 XB assembler: vector alignment marker", "[gsc][assembler][iw5][xb2]")
+{
+    iw5_xb::context context(instance::server);
+    auto program = assembly::make();
+    auto function = function::make();
+    function->id = 1;
+
+    for (auto i = 0; i < 3; ++i)
+    {
+        auto instruction = instruction::make();
+        instruction->opcode = opcode::OP_GetZero;
+        function->instructions.push_back(std::move(instruction));
+    }
+
+    auto vector = instruction::make();
+    vector->opcode = opcode::OP_GetVector;
+    vector->data = { "0", "0", "0" };
+    function->instructions.push_back(std::move(vector));
+    program->functions.push_back(std::move(function));
+
+    auto const [script, stack, devmap] = context.assembler().assemble(*program);
+    auto const vector_opcode = context.opcode_id(opcode::OP_GetVector);
+
+    REQUIRE(script.size == 20);
+    REQUIRE(script.data[4] == vector_opcode);
+    REQUIRE(script.data[5] == 0);
+    REQUIRE(script.data[6] == 0);
+    REQUIRE(script.data[7] == vector_opcode);
+
+    for (usize i = 8; i < 20; ++i)
+    {
+        REQUIRE(script.data[i] == 0);
+    }
+}
+
+} // namespace xsk::test


### PR DESCRIPTION
Fixes the crash observed while porting [IW5 Bot Warfare to Xbox 360](https://github.com/codxenon/iw5-bot-warfare-xenon).

Stock IW5 Xenon scripts encode `OP_GetVector` (`0x0F`) in the final byte of vector-alignment padding. The assembler previously emitted zero-filled padding:

```text
before: 0F 00 00 00 <12-byte vector>
after:  0F 00 00 0F <12-byte vector>
```

Matching the retail bytecode layout resolved the crash. The change is IW5 Xbox 360-only and includes a regression test.